### PR TITLE
Add FastAPI API and React frontend with mock payment

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,15 @@
+# syntax=docker/dockerfile:1
+
+FROM python:3.11-slim
+
+WORKDIR /app
+
+# Install Python dependencies
+COPY ../requirements.txt ./requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy source code
+COPY .. .
+
+CMD ["uvicorn", "backend.main:app", "--host", "0.0.0.0", "--port", "8000"]
+

--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -1,0 +1,2 @@
+"""Backend package for FastAPI application."""
+

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,96 @@
+"""FastAPI application exposing menu, cart, delivery and payment endpoints.
+
+These endpoints mirror the business logic of the Telegram bot handlers
+implemented in :mod:`app.handlers` and use the in-memory storage from
+``app.storage``.  The API is intentionally simple and stores cart and delivery
+information in memory for demonstration purposes.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List
+from uuid import uuid4
+
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+
+from app.storage import MENU_ITEMS, SKU_INDEX, get_cart, commit_order
+
+
+app = FastAPI(title="menuBot API")
+
+
+@app.get("/api/menu")
+def api_menu() -> Dict[str, List[Dict]]:
+    """Return available menu items grouped by category."""
+    return MENU_ITEMS
+
+
+class CartItem(BaseModel):
+    sku: str
+    qty: int = 1
+
+
+@app.get("/api/cart")
+def api_get_cart(user_id: int = 1) -> Dict:
+    """Return current cart contents for ``user_id``."""
+    cart = get_cart(user_id)
+    items = []
+    for ci in cart.items.values():
+        data = SKU_INDEX.get(ci.sku)
+        if not data:
+            continue
+        items.append({**data, "qty": ci.qty})
+    return {"items": items, "total": cart.total()}
+
+
+@app.post("/api/cart")
+def api_add_cart(item: CartItem, user_id: int = 1) -> Dict:
+    """Add an item to the cart."""
+    cart = get_cart(user_id)
+    try:
+        cart.add(item.sku, item.qty)
+    except ValueError as exc:  # pragma: no cover - simple error propagation
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    return api_get_cart(user_id)
+
+
+@app.delete("/api/cart/{sku}")
+def api_remove_cart(sku: str, user_id: int = 1) -> Dict:
+    """Remove an item from the cart by SKU."""
+    cart = get_cart(user_id)
+    cart.remove(sku)
+    return api_get_cart(user_id)
+
+
+class DeliveryInfo(BaseModel):
+    address: str
+    name: str
+    phone: str
+
+
+_delivery_data: Dict[int, DeliveryInfo] = {}
+
+
+@app.post("/api/delivery")
+def api_delivery(info: DeliveryInfo, user_id: int = 1) -> Dict[str, str]:
+    """Store delivery information for ``user_id``."""
+    _delivery_data[user_id] = info
+    return {"status": "ok"}
+
+
+class PaymentRequest(BaseModel):
+    method: str  # "cash" or "online"
+
+
+@app.post("/api/payment")
+def api_payment(req: PaymentRequest, user_id: int = 1) -> Dict:
+    """Mock payment processing and create an order."""
+    delivery = _delivery_data.get(user_id, DeliveryInfo(address="", name="", phone=""))
+    payment = {
+        "method": req.method,
+        "transaction_id": f"TX-{uuid4().hex[:8]}",
+    }
+    order = commit_order(user_id, delivery.model_dump(), payment)
+    return {"status": "ok", "order": order}
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+version: "3.9"
+
+services:
+  backend:
+    build: ./backend
+    ports:
+      - "8000:8000"
+
+  frontend:
+    build: ./frontend
+    ports:
+      - "3000:3000"
+

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,15 @@
+# syntax=docker/dockerfile:1
+
+FROM node:18-alpine
+
+WORKDIR /app
+
+COPY package.json ./
+RUN npm install --production
+
+COPY . .
+
+RUN npm run build
+
+CMD ["npm", "start"]
+

--- a/frontend/components/RotatingCard.js
+++ b/frontend/components/RotatingCard.js
@@ -1,0 +1,38 @@
+import { useEffect, useRef } from 'react';
+import * as THREE from 'three';
+
+// A very small Three.js scene that rotates a textured cube
+export default function RotatingCard({ image }) {
+  const mountRef = useRef(null);
+
+  useEffect(() => {
+    const scene = new THREE.Scene();
+    const camera = new THREE.PerspectiveCamera(75, 1, 0.1, 1000);
+    const renderer = new THREE.WebGLRenderer({ antialias: true });
+    renderer.setSize(200, 200);
+    mountRef.current.appendChild(renderer.domElement);
+
+    const geometry = new THREE.BoxGeometry();
+    const texture = new THREE.TextureLoader().load(image);
+    const material = new THREE.MeshBasicMaterial({ map: texture });
+    const cube = new THREE.Mesh(geometry, material);
+    scene.add(cube);
+
+    camera.position.z = 2;
+
+    const animate = () => {
+      requestAnimationFrame(animate);
+      cube.rotation.x += 0.01;
+      cube.rotation.y += 0.01;
+      renderer.render(scene, camera);
+    };
+    animate();
+
+    return () => {
+      mountRef.current.removeChild(renderer.domElement);
+    };
+  }, [image]);
+
+  return <div ref={mountRef} />;
+}
+

--- a/frontend/hooks/useCart.js
+++ b/frontend/hooks/useCart.js
@@ -1,0 +1,34 @@
+import { useState, useEffect } from 'react';
+
+// Simple cart hook that persists state in localStorage
+export default function useCart() {
+  const [cart, setCart] = useState({});
+
+  useEffect(() => {
+    const stored = localStorage.getItem('cart');
+    if (stored) {
+      setCart(JSON.parse(stored));
+    }
+  }, []);
+
+  useEffect(() => {
+    localStorage.setItem('cart', JSON.stringify(cart));
+  }, [cart]);
+
+  const add = (sku) => {
+    setCart((prev) => ({ ...prev, [sku]: (prev[sku] || 0) + 1 }));
+  };
+
+  const remove = (sku) => {
+    setCart((prev) => {
+      const next = { ...prev };
+      delete next[sku];
+      return next;
+    });
+  };
+
+  const clear = () => setCart({});
+
+  return { cart, add, remove, clear };
+}
+

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -1,0 +1,7 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+};
+
+module.exports = nextConfig;
+

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "menubot-frontend",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "test": "echo \"No tests\""
+  },
+  "dependencies": {
+    "axios": "^1.5.0",
+    "next": "13.5.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "three": "^0.158.0"
+  }
+}
+

--- a/frontend/pages/_app.js
+++ b/frontend/pages/_app.js
@@ -1,0 +1,6 @@
+import '../styles/globals.css';
+
+export default function App({ Component, pageProps }) {
+  return <Component {...pageProps} />;
+}
+

--- a/frontend/pages/cart.js
+++ b/frontend/pages/cart.js
@@ -1,0 +1,36 @@
+import { useEffect, useState } from 'react';
+import axios from 'axios';
+import useCart from '../hooks/useCart';
+
+export default function Cart() {
+  const { cart, remove, clear } = useCart();
+  const [items, setItems] = useState([]);
+
+  useEffect(() => {
+    axios.get('/api/menu').then((res) => {
+      const all = Object.values(res.data).flat();
+      const mapped = Object.entries(cart).map(([sku, qty]) => {
+        const data = all.find((i) => i.sku === sku);
+        return { ...data, qty };
+      });
+      setItems(mapped);
+    });
+  }, [cart]);
+
+  const total = items.reduce((s, it) => s + it.price * it.qty, 0);
+
+  return (
+    <div>
+      <h1>Cart</h1>
+      {items.map((item) => (
+        <div key={item.sku}>
+          {item.title} x{item.qty} - {item.price * item.qty} VND
+          <button onClick={() => remove(item.sku)}>Remove</button>
+        </div>
+      ))}
+      <p>Total: {total} VND</p>
+      <button onClick={clear}>Clear</button>
+    </div>
+  );
+}
+

--- a/frontend/pages/checkout.js
+++ b/frontend/pages/checkout.js
@@ -1,0 +1,46 @@
+import { useState } from 'react';
+import axios from 'axios';
+import useCart from '../hooks/useCart';
+
+export default function Checkout() {
+  const { clear } = useCart();
+  const [form, setForm] = useState({ address: '', name: '', phone: '', method: 'cash' });
+  const [result, setResult] = useState(null);
+
+  const handleChange = (e) => setForm({ ...form, [e.target.name]: e.target.value });
+
+  const submit = async () => {
+    await axios.post('/api/delivery', {
+      address: form.address,
+      name: form.name,
+      phone: form.phone,
+    });
+    const res = await axios.post('/api/payment', { method: form.method });
+    clear();
+    setResult(res.data.order);
+  };
+
+  if (result) {
+    return (
+      <div>
+        <h1>Order confirmed</h1>
+        <p>Transaction: {result.payment.transaction_id}</p>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <h1>Checkout</h1>
+      <input name="address" placeholder="Address" value={form.address} onChange={handleChange} />
+      <input name="name" placeholder="Name" value={form.name} onChange={handleChange} />
+      <input name="phone" placeholder="Phone" value={form.phone} onChange={handleChange} />
+      <select name="method" value={form.method} onChange={handleChange}>
+        <option value="cash">Cash</option>
+        <option value="online">Online</option>
+      </select>
+      <button onClick={submit}>Pay</button>
+    </div>
+  );
+}
+

--- a/frontend/pages/contact.js
+++ b/frontend/pages/contact.js
@@ -1,0 +1,9 @@
+export default function Contact() {
+  return (
+    <div>
+      <h1>Contact</h1>
+      <p>Email: info@example.com</p>
+    </div>
+  );
+}
+

--- a/frontend/pages/index.js
+++ b/frontend/pages/index.js
@@ -1,0 +1,16 @@
+import Link from 'next/link';
+
+export default function Home() {
+  return (
+    <div>
+      <h1>Welcome to menuBot</h1>
+      <nav>
+        <Link href="/menu">Menu</Link>
+        <Link href="/cart">Cart</Link>
+        <Link href="/checkout">Checkout</Link>
+        <Link href="/contact">Contact</Link>
+      </nav>
+    </div>
+  );
+}
+

--- a/frontend/pages/menu.js
+++ b/frontend/pages/menu.js
@@ -1,0 +1,37 @@
+import { useEffect, useState } from 'react';
+import axios from 'axios';
+import useCart from '../hooks/useCart';
+import styles from '../styles/Menu.module.css';
+import RotatingCard from '../components/RotatingCard';
+
+export default function Menu() {
+  const [menu, setMenu] = useState({});
+  const { add } = useCart();
+
+  useEffect(() => {
+    axios.get('/api/menu').then((res) => setMenu(res.data));
+  }, []);
+
+  return (
+    <div>
+      <h1>Menu</h1>
+      {Object.entries(menu).map(([cat, items]) => (
+        <div key={cat}>
+          <h2>{cat}</h2>
+          <div className={styles.grid}>
+            {items.map((item) => (
+              <div key={item.sku} className={styles.card}>
+                <RotatingCard image={item.photo} />
+                <h3>{item.title}</h3>
+                <p>{item.desc}</p>
+                <p>{item.price} VND</p>
+                <button onClick={() => add(item.sku)}>Add to cart</button>
+              </div>
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+

--- a/frontend/styles/Menu.module.css
+++ b/frontend/styles/Menu.module.css
@@ -1,0 +1,18 @@
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: 1rem;
+}
+
+.card {
+  border: 1px solid #ddd;
+  padding: 1rem;
+  text-align: center;
+}
+
+@media (max-width: 600px) {
+  .grid {
+    grid-template-columns: 1fr;
+  }
+}
+

--- a/frontend/styles/globals.css
+++ b/frontend/styles/globals.css
@@ -1,0 +1,15 @@
+body {
+  margin: 0;
+  font-family: sans-serif;
+}
+
+a {
+  margin-right: 1rem;
+}
+
+@media (max-width: 600px) {
+  .grid {
+    grid-template-columns: 1fr;
+  }
+}
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 aiogram==3.10.0
 python-dotenv==1.0.1
+fastapi==0.111.0
+uvicorn[standard]==0.30.1


### PR DESCRIPTION
## Summary
- add FastAPI app exposing `/api/menu`, `/api/cart`, `/api/delivery`, and `/api/payment`
- introduce React/Next.js frontend with menu, cart, checkout, and contact pages
- include Docker configs and docker-compose for backend/frontend deployment

## Testing
- `pip install -r requirements.txt` (fails: Could not find a version that satisfies the requirement fastapi==0.111.0)
- `pytest`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac7d9b05288326a7b32bde95860cdf